### PR TITLE
simplify UberStateType checks

### DIFF
--- a/projects/RandoMainDLL/Extensions.cs
+++ b/projects/RandoMainDLL/Extensions.cs
@@ -31,31 +31,31 @@ namespace RandoMainDLL {
     }
 
     public static int AsInt(this UberValue v, UberStateType t) {
-      return t.simplify() switch {
-        SimplifiedUberStateType.Boolean => Convert.ToInt32(v.Bool),
-        SimplifiedUberStateType.Byte => Convert.ToInt32(v.Byte),
-        SimplifiedUberStateType.Int => v.Int,
-        SimplifiedUberStateType.Float => Convert.ToInt32(v.Float),
+      return t.baseType() switch {
+        UberStateBaseType.Boolean => Convert.ToInt32(v.Bool),
+        UberStateBaseType.Byte => Convert.ToInt32(v.Byte),
+        UberStateBaseType.Int => v.Int,
+        UberStateBaseType.Float => Convert.ToInt32(v.Float),
         _ => v.Int,
       };
     }
 
     public static double AsDouble(this UberValue v, UberStateType t) {
-      return t.simplify() switch {
-        SimplifiedUberStateType.Boolean => v.Bool ? 1.0f : 0.0f,
-        SimplifiedUberStateType.Byte => Convert.ToDouble(v.Byte),
-        SimplifiedUberStateType.Int => Convert.ToDouble(v.Int),
-        SimplifiedUberStateType.Float => Convert.ToDouble(v.Float),
+      return t.baseType() switch {
+        UberStateBaseType.Boolean => v.Bool ? 1.0f : 0.0f,
+        UberStateBaseType.Byte => Convert.ToDouble(v.Byte),
+        UberStateBaseType.Int => Convert.ToDouble(v.Int),
+        UberStateBaseType.Float => Convert.ToDouble(v.Float),
         _ => Convert.ToDouble(v.Int),
       };
     }
 
     public static bool AsBool(this UberValue v, UberStateType t) {
-      return t.simplify() switch {
-        SimplifiedUberStateType.Boolean => v.Bool,
-        SimplifiedUberStateType.Byte => Convert.ToBoolean(v.Byte),
-        SimplifiedUberStateType.Int => Convert.ToBoolean(v.Int),
-        SimplifiedUberStateType.Float => Convert.ToBoolean(v.Float),
+      return t.baseType() switch {
+        UberStateBaseType.Boolean => v.Bool,
+        UberStateBaseType.Byte => Convert.ToBoolean(v.Byte),
+        UberStateBaseType.Int => Convert.ToBoolean(v.Int),
+        UberStateBaseType.Float => Convert.ToBoolean(v.Float),
         _ => Convert.ToBoolean(v.Int),
       };
     }

--- a/projects/RandoMainDLL/Extensions.cs
+++ b/projects/RandoMainDLL/Extensions.cs
@@ -31,7 +31,7 @@ namespace RandoMainDLL {
     }
 
     public static int AsInt(this UberValue v, UberStateType t) {
-      return t.baseType() switch {
+      return t.ToBaseType() switch {
         UberStateBaseType.Boolean => Convert.ToInt32(v.Bool),
         UberStateBaseType.Byte => Convert.ToInt32(v.Byte),
         UberStateBaseType.Int => v.Int,
@@ -41,7 +41,7 @@ namespace RandoMainDLL {
     }
 
     public static double AsDouble(this UberValue v, UberStateType t) {
-      return t.baseType() switch {
+      return t.ToBaseType() switch {
         UberStateBaseType.Boolean => v.Bool ? 1.0f : 0.0f,
         UberStateBaseType.Byte => Convert.ToDouble(v.Byte),
         UberStateBaseType.Int => Convert.ToDouble(v.Int),
@@ -51,7 +51,7 @@ namespace RandoMainDLL {
     }
 
     public static bool AsBool(this UberValue v, UberStateType t) {
-      return t.baseType() switch {
+      return t.ToBaseType() switch {
         UberStateBaseType.Boolean => v.Bool,
         UberStateBaseType.Byte => Convert.ToBoolean(v.Byte),
         UberStateBaseType.Int => Convert.ToBoolean(v.Int),

--- a/projects/RandoMainDLL/Extensions.cs
+++ b/projects/RandoMainDLL/Extensions.cs
@@ -27,73 +27,37 @@ namespace RandoMainDLL {
     public static T FirstOrElse<T>(this IEnumerable<T> l, Func<T, bool> selector, T def) => l.Where(selector).FirstOrElse(def);
 
     public static string FmtVal(this UberValue Value, UberStateType t) {
-      switch (t) {
-        case UberStateType.SavePedestalUberState:
-        case UberStateType.SerializedBooleanUberState:
-          return $"{Value.Bool}";
-        case UberStateType.SerializedByteUberState:
-          return $"{Value.Byte}";
-        case UberStateType.SerializedIntUberState:
-          return $"{Value.Int}";
-        case UberStateType.SerializedFloatUberState:
-          return $"{Value.Float}";
-      }
-      return $"{t}-{Value}";
-
+      return Value.FmtVal(t);
     }
 
     public static int AsInt(this UberValue v, UberStateType t) {
-      switch(t) {
-        case UberStateType.SavePedestalUberState:
-        case UberStateType.ByteUberState:
-        case UberStateType.SerializedByteUberState:
-          return Convert.ToInt32(v.Byte);
-        case UberStateType.BooleanUberState:
-        case UberStateType.SerializedBooleanUberState:
-          return Convert.ToInt32(v.Bool);
-        case UberStateType.SerializedFloatUberState:
-          return Convert.ToInt32(v.Float);
-        case UberStateType.IntUberState:
-        case UberStateType.SerializedIntUberState:
-        default:
-          return v.Int;
-      }
+      return t.simplify() switch {
+        SimplifiedUberStateType.Boolean => Convert.ToInt32(v.Bool),
+        SimplifiedUberStateType.Byte => Convert.ToInt32(v.Byte),
+        SimplifiedUberStateType.Int => v.Int,
+        SimplifiedUberStateType.Float => Convert.ToInt32(v.Float),
+        _ => v.Int,
+      };
     }
 
     public static double AsDouble(this UberValue v, UberStateType t) {
-      switch (t) {
-        case UberStateType.SavePedestalUberState:
-        case UberStateType.ByteUberState:
-        case UberStateType.SerializedByteUberState:
-          return Convert.ToDouble(v.Byte);
-        case UberStateType.BooleanUberState:
-        case UberStateType.SerializedBooleanUberState:
-          return v.Bool ? 1.0f : 0.0f;
-        case UberStateType.SerializedFloatUberState:
-          return Convert.ToDouble(v.Float);
-        case UberStateType.IntUberState:
-        case UberStateType.SerializedIntUberState:
-        default:
-          return Convert.ToDouble(v.Int);
-      }
+      return t.simplify() switch {
+        SimplifiedUberStateType.Boolean => v.Bool ? 1.0f : 0.0f,
+        SimplifiedUberStateType.Byte => Convert.ToDouble(v.Byte),
+        SimplifiedUberStateType.Int => Convert.ToDouble(v.Int),
+        SimplifiedUberStateType.Float => Convert.ToDouble(v.Float),
+        _ => Convert.ToDouble(v.Int),
+      };
     }
 
     public static bool AsBool(this UberValue v, UberStateType t) {
-      switch (t) {
-        case UberStateType.SavePedestalUberState:
-        case UberStateType.ByteUberState:
-        case UberStateType.SerializedByteUberState:
-          return Convert.ToBoolean(v.Byte);
-        case UberStateType.BooleanUberState:
-        case UberStateType.SerializedBooleanUberState:
-          return v.Bool;
-        case UberStateType.SerializedFloatUberState:
-          return Convert.ToBoolean(v.Float);
-        case UberStateType.IntUberState:
-        case UberStateType.SerializedIntUberState:
-        default:
-          return Convert.ToBoolean(v.Int);
-      }
+      return t.simplify() switch {
+        SimplifiedUberStateType.Boolean => v.Bool,
+        SimplifiedUberStateType.Byte => Convert.ToBoolean(v.Byte),
+        SimplifiedUberStateType.Int => Convert.ToBoolean(v.Int),
+        SimplifiedUberStateType.Float => Convert.ToBoolean(v.Float),
+        _ => Convert.ToBoolean(v.Int),
+      };
     }
     public static void Refresh(this UberId id) => InterOp.UberState.refresh_uber_state(id.GroupID, id.ID);
     public static EquipmentType? Equip(this AbilityType t) => AbilityToEquip.Get(t);

--- a/projects/RandoMainDLL/Memory/UberState.cs
+++ b/projects/RandoMainDLL/Memory/UberState.cs
@@ -16,7 +16,7 @@ namespace RandoMainDLL.Memory {
     PlayerUberStateDescriptor
   }
 
-  public enum SimplifiedUberStateType : byte {
+  public enum UberStateBaseType : byte {
     Boolean,
     Byte,
     Int,
@@ -25,13 +25,13 @@ namespace RandoMainDLL.Memory {
   }
 
   public static class Extensions {
-    public static SimplifiedUberStateType simplify(this UberStateType type) {
+    public static UberStateBaseType baseType(this UberStateType type) {
       return type switch {
-        UberStateType.BooleanUberState or UberStateType.SerializedBooleanUberState or UberStateType.SavePedestalUberState => SimplifiedUberStateType.Boolean,
-        UberStateType.ByteUberState or UberStateType.SerializedByteUberState => SimplifiedUberStateType.Byte,
-        UberStateType.IntUberState or UberStateType.SerializedIntUberState => SimplifiedUberStateType.Int,
-        UberStateType.SerializedFloatUberState => SimplifiedUberStateType.Float,
-        _ => SimplifiedUberStateType.Other,
+        UberStateType.BooleanUberState or UberStateType.SerializedBooleanUberState or UberStateType.SavePedestalUberState => UberStateBaseType.Boolean,
+        UberStateType.ByteUberState or UberStateType.SerializedByteUberState => UberStateBaseType.Byte,
+        UberStateType.IntUberState or UberStateType.SerializedIntUberState => UberStateBaseType.Int,
+        UberStateType.SerializedFloatUberState => UberStateBaseType.Float,
+        _ => UberStateBaseType.Other,
       };
     }
   }
@@ -221,20 +221,20 @@ namespace RandoMainDLL.Memory {
     public UberState Clone() => new UberState() { Type = Type, ID = ID, Name = Name, GroupID = GroupID, GroupName = GroupName, Value = Value };
 
     public bool IsObjectType => Type == UberStateType.SavePedestalUberState || Type == UberStateType.PlayerUberStateDescriptor;
-    public bool IsBoolType => Type.simplify() == SimplifiedUberStateType.Boolean;
-    public bool IsIntType => Type.simplify() == SimplifiedUberStateType.Int;
-    public bool IsFloatType => Type.simplify() == SimplifiedUberStateType.Float;
-    public bool IsByteType => Type.simplify() == SimplifiedUberStateType.Byte;
+    public bool IsBoolType => Type.baseType() == UberStateBaseType.Boolean;
+    public bool IsIntType => Type.baseType() == UberStateBaseType.Int;
+    public bool IsFloatType => Type.baseType() == UberStateBaseType.Float;
+    public bool IsByteType => Type.baseType() == UberStateBaseType.Byte;
 
     public string FmtVal() {
       return Value.FmtVal(Type);
     }
     public override string ToString() {
-      return Type.simplify() switch {
-        SimplifiedUberStateType.Boolean => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value.Bool}",
-        SimplifiedUberStateType.Byte => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value.Byte}",
-        SimplifiedUberStateType.Int => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value.Int}",
-        SimplifiedUberStateType.Float => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value.Float}",
+      return Type.baseType() switch {
+        UberStateBaseType.Boolean => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value.Bool}",
+        UberStateBaseType.Byte => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value.Byte}",
+        UberStateBaseType.Int => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value.Int}",
+        UberStateBaseType.Float => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value.Float}",
         _ => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value}",
       };
     }
@@ -249,14 +249,14 @@ namespace RandoMainDLL.Memory {
       Int = 0;
       Float = 0f;
 
-      switch (t.simplify()) {
-        case SimplifiedUberStateType.Boolean:
+      switch (t.baseType()) {
+        case UberStateBaseType.Boolean:
           Bool = !(Math.Abs(value) < 0.001f);
           return;
-        case SimplifiedUberStateType.Byte:
+        case UberStateBaseType.Byte:
           Byte = (byte)value;
           return;
-        case SimplifiedUberStateType.Int:
+        case UberStateBaseType.Int:
           Int = (int)value;
           return;
         default:
@@ -299,11 +299,11 @@ namespace RandoMainDLL.Memory {
     public bool Bool;
 
     public string FmtVal(UberStateType Type) {
-      return Type.simplify() switch {
-        SimplifiedUberStateType.Boolean => $"{Bool}",
-        SimplifiedUberStateType.Byte => $"{Byte}",
-        SimplifiedUberStateType.Int => $"{Int}",
-        SimplifiedUberStateType.Float => $"{Float}",
+      return Type.baseType() switch {
+        UberStateBaseType.Boolean => $"{Bool}",
+        UberStateBaseType.Byte => $"{Byte}",
+        UberStateBaseType.Int => $"{Int}",
+        UberStateBaseType.Float => $"{Float}",
         _ => $"{Type}-{ToString()}",
       };
     }

--- a/projects/RandoMainDLL/Memory/UberState.cs
+++ b/projects/RandoMainDLL/Memory/UberState.cs
@@ -25,7 +25,7 @@ namespace RandoMainDLL.Memory {
   }
 
   public static class Extensions {
-    public static UberStateBaseType baseType(this UberStateType type) {
+    public static UberStateBaseType ToBaseType(this UberStateType type) {
       return type switch {
         UberStateType.BooleanUberState or UberStateType.SerializedBooleanUberState or UberStateType.SavePedestalUberState => UberStateBaseType.Boolean,
         UberStateType.ByteUberState or UberStateType.SerializedByteUberState => UberStateBaseType.Byte,
@@ -221,16 +221,16 @@ namespace RandoMainDLL.Memory {
     public UberState Clone() => new UberState() { Type = Type, ID = ID, Name = Name, GroupID = GroupID, GroupName = GroupName, Value = Value };
 
     public bool IsObjectType => Type == UberStateType.SavePedestalUberState || Type == UberStateType.PlayerUberStateDescriptor;
-    public bool IsBoolType => Type.baseType() == UberStateBaseType.Boolean;
-    public bool IsIntType => Type.baseType() == UberStateBaseType.Int;
-    public bool IsFloatType => Type.baseType() == UberStateBaseType.Float;
-    public bool IsByteType => Type.baseType() == UberStateBaseType.Byte;
+    public bool IsBoolType => Type.ToBaseType() == UberStateBaseType.Boolean;
+    public bool IsIntType => Type.ToBaseType() == UberStateBaseType.Int;
+    public bool IsFloatType => Type.ToBaseType() == UberStateBaseType.Float;
+    public bool IsByteType => Type.ToBaseType() == UberStateBaseType.Byte;
 
     public string FmtVal() {
       return Value.FmtVal(Type);
     }
     public override string ToString() {
-      return Type.baseType() switch {
+      return Type.ToBaseType() switch {
         UberStateBaseType.Boolean => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value.Bool}",
         UberStateBaseType.Byte => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value.Byte}",
         UberStateBaseType.Int => $"{Name}[{ID}]({GroupName}[{GroupID}]) = {Value.Int}",
@@ -249,7 +249,7 @@ namespace RandoMainDLL.Memory {
       Int = 0;
       Float = 0f;
 
-      switch (t.baseType()) {
+      switch (t.ToBaseType()) {
         case UberStateBaseType.Boolean:
           Bool = !(Math.Abs(value) < 0.001f);
           return;
@@ -299,7 +299,7 @@ namespace RandoMainDLL.Memory {
     public bool Bool;
 
     public string FmtVal(UberStateType Type) {
-      return Type.baseType() switch {
+      return Type.ToBaseType() switch {
         UberStateBaseType.Boolean => $"{Bool}",
         UberStateBaseType.Byte => $"{Byte}",
         UberStateBaseType.Int => $"{Int}",

--- a/projects/RandoMainDLL/UberStateController.cs
+++ b/projects/RandoMainDLL/UberStateController.cs
@@ -228,18 +228,7 @@ namespace RandoMainDLL {
     }
 
     public static UberValue CreateValue(UberStateType type, double value) {
-      switch (type) {
-        case UberStateType.PlayerUberStateDescriptor:
-        case UberStateType.SavePedestalUberState:
-        case UberStateType.SerializedByteUberState:
-          return new UberValue((byte)value);
-        case UberStateType.SerializedBooleanUberState:
-          return new UberValue(!(Math.Abs(value) < 0.001f));
-        case UberStateType.SerializedIntUberState:
-          return new UberValue((int)value);
-        default:
-          return new UberValue((float)value);
-      }
+      return new UberValue(type, value);
     }
 
     private static HashSet<UberId> RaceIDs = new HashSet<UberId> {


### PR DESCRIPTION
Attempts to create coherence in how UberStateTypes are checked and handled by introducing a new `UberStateBaseType`.

Not all existing behaviour was strictly preserved since there were many redundant methods that sometimes had slightly different behaviours (e.g. casting to in vs. using `Convert`) which now call into shared methods to ensure consistency.

As a consequence, many bugs involving non-serialized UberStates are fixed since non-serialized and serialized UberStates behave in a consistent manner now.

I didn't spot any newly introduced bugs by the refactor, but didn't test very extensively.